### PR TITLE
Fix for PATH_MAX undefined compilation error on MAC

### DIFF
--- a/mkqcdtbootimg.c
+++ b/mkqcdtbootimg.c
@@ -43,6 +43,10 @@
 #endif
 #include "bootimg.h"
 
+#ifndef PATH_MAX
+#define PATH_MAX 4096
+#endif
+
 struct dt_blob;
 
 /*


### PR DESCRIPTION
It checks if variable is already defined, so it won't cause error on other platforms where this variable is already defined.

It defines the variable only when the variable is not defined.