### PR TITLE
mkqcdtbootimg: fix header include

### DIFF
--- a/libfdt/fdt_ro.c
+++ b/libfdt/fdt_ro.c
@@ -52,6 +52,7 @@
 
 #include <fdt.h>
 #include <libfdt.h>
+#include <stdio.h>
 
 #include "libfdt_internal.h"
 


### PR DESCRIPTION
vendor/sony/system/mkqcdtbootimg/libfdt/fdt_ro.c:67:2: note: include the header <stdio.h> or explicitly provide a declaration for 'printf'

Signed-off-by: David Viteri davidteri91@gmail.com
